### PR TITLE
this enables setting a proxy when connecting to external sites.

### DIFF
--- a/configuration.py
+++ b/configuration.py
@@ -47,3 +47,4 @@ include_performers_in_title = True #If True, performers will be added at the beg
 clean_filename = True #If True, will try to clean up filenames before attempting scrape. Often unnecessary, as ThePornDB already does this
 compact_studio_names = True # If True, this will remove spaces from studio names added from ThePornDB
 ignore_ssl_warnings= True # Set to True if your Stash uses SSL w/ a self-signed cert
+proxies={} # Leave empty or specify proxy like this: {'http':'http://user:pass@10.10.10.10:8000','https':'https://user:pass@10.10.10.10:8000'}

--- a/scrapeScenes.py
+++ b/scrapeScenes.py
@@ -341,12 +341,12 @@ class stash_interface:
 
     def getPerformerImage(self, url):  #UNTESTED
         if self.http_auth_type == "basic":
-            return base64.b64encode(requests.get(url, auth=requests.auth.HTTPBasicAuth(self.username, self.password), 
+            return base64.b64encode(requests.get(url,proxies=config.proxies, auth=requests.auth.HTTPBasicAuth(self.username, self.password), 
                                 verify= not self.ignore_ssl_warnings).content)
         elif self.http_auth_type == "jwt":
-            return base64.b64encode(requests.get(url, headers=self.headers, cookies={'session':self.auth_token}, verify= not self.ignore_ssl_warnings).content)
+            return base64.b64encode(requests.get(url,proxies=config.proxies, headers=self.headers, cookies={'session':self.auth_token}, verify= not self.ignore_ssl_warnings).content)
         else:
-            return base64.b64encode(requests.get(url, verify= not self.ignore_ssl_warnings).content)        
+            return base64.b64encode(requests.get(url,proxies=config.proxies, verify= not self.ignore_ssl_warnings).content)        
         
     def addStudio(self, studio_data):
         query = """
@@ -598,7 +598,7 @@ def createStashStudioData(tpbd_studio):  # Creates stash-compliant data from raw
         stash_studio["name"] = tpbd_studio["name"]
     stash_studio["url"] = tpbd_studio["url"]
     if tpbd_studio["logo"] is not None and "default.png" not in tpbd_studio["logo"]:
-        image = requests.get(tpbd_studio["logo"]).content
+        image = requests.get(tpbd_studio["logo"],proxies=config.proxies).content
         image_b64 = base64.b64encode(image)
         stash_studio["image"] = image_b64.decode(ENCODING)
 
@@ -606,7 +606,7 @@ def createStashStudioData(tpbd_studio):  # Creates stash-compliant data from raw
 
 def getJpegImage(image_url):
     try:
-        r = requests.get(image_url, stream=True)
+        r = requests.get(image_url, stream=True,proxies=config.proxies)
         r.raw.decode_content = True # handle spurious Content-Encoding
         image = Image.open(r.raw)
         if image.format:
@@ -622,14 +622,14 @@ def getJpegImage(image_url):
 
 def getBabepediaImage(name):
     url = "https://www.babepedia.com/pics/"+urllib.parse.quote(name)+".jpg"
-    if requests.get(url):
+    if requests.get(url,proxies=config.proxies):
         return getJpegImage(url)
     return None
 
 def getTpbdImage(name):
     url = "https://metadataapi.net/api/performers?q="+urllib.parse.quote(name)
-    if len(requests.get(url).json()["data"])==1: #If we only have 1 hit
-        raw_data = requests.get(url).json()["data"][0]
+    if len(requests.get(url,proxies=config.proxies).json()["data"])==1: #If we only have 1 hit
+        raw_data = requests.get(url,proxies=config.proxies).json()["data"][0]
         image_url = raw_data["image"]
         if not "default.png" in image_url:
             image = getJpegImage(image_url)
@@ -677,11 +677,11 @@ def getPerformer(name):
     search_url = "https://metadataapi.net/api/performers?q="+urllib.parse.quote(name)
     data_url_prefix = "https://metadataapi.net/api/performers/"
     try:
-        result = requests.get(search_url).json()
+        result = requests.get(search_url,proxies=config.proxies).json()
         tpbd_error_count = 0
         if result.get("data", [{}])[0].get("id", None):
             performer_id = result["data"][0]["id"]
-            return requests.get(data_url_prefix+performer_id).json()["data"]
+            return requests.get(data_url_prefix+performer_id,proxies=config.proxies).json()["data"]
         else:
             return None
     except ValueError:
@@ -699,7 +699,7 @@ def sceneQuery(query, parse_function = True):  # Scrapes ThePornDB based on quer
     else:
         url = "https://metadataapi.net/api/scenes?q="+urllib.parse.quote(query)
     try:
-        result = requests.get(url).json()["data"]
+        result = requests.get(url,proxies=config.proxies).json()["data"]
         tpbd_error_count = 0
         return result
     except ValueError:

--- a/scrapeScenes.py
+++ b/scrapeScenes.py
@@ -1129,6 +1129,7 @@ class config_class:
     compact_studio_names = False # If true, this will remove spaces from studio names added from ThePornDB
     ignore_ssl_warnings = False # Set to true if your Stash uses SSL w/ a self-signed cert
     trust_tpbd_aliases = False #Trust TPBDs aliases without double checking
+    proxies={} # Leave empty or specify proxy like this: {'http':'http://user:pass@10.10.10.10:8000','https':'https://user:pass@10.10.10.10:8000'}
 
     def loadConfig(self):
         try:  # Try to load configuration.py values
@@ -1214,7 +1215,9 @@ include_performers_in_title = True #If true, performers will be added to the beg
 clean_filename = True #If True, will try to clean up filenames before attempting scrape. Probably unnecessary, as ThePornDB already does this
 compact_studio_names = False # If True, this will remove spaces from studio names added from ThePornDB
 ignore_ssl_warnings=True # Set to True if your Stash uses SSL w/ a self-signed cert
-trust_tpbd_aliases = False #Trust TPBDs aliases without double checking""".format(server_ip, server_port, username, password, use_https))
+trust_tpbd_aliases = False #Trust TPBDs aliases without double checking
+proxies={} # Leave empty or specify proxy like this: {'http':'http://user:pass@10.10.10.10:8000','https':'https://user:pass@10.10.10.10:8000'}
+""".format(server_ip, server_port, username, password, use_https))
         f.close()
         print("Configuration file created.  All values are currently at defaults.  It is highly recommended that you edit the configuration.py to your liking.  Otherwise, just re-run the script to use the defaults.")
         sys.exit()


### PR DESCRIPTION
any `requests.get() `or `request.post() `that has a url that goes to the web most have `proxies=config.proxies`.